### PR TITLE
Remove unnecessary manual call epmd -daemon

### DIFF
--- a/edb_core/test/edb_test_support.erl
+++ b/edb_core/test/edb_test_support.erl
@@ -272,17 +272,10 @@ event_collector_send_sync() ->
 %% Helpers
 %% --------------------------------------------------------------------
 
--spec ensure_epmd() -> ok.
-ensure_epmd() ->
-    (erl_epmd:names("localhost") =:= {error, address}) andalso
-        ([] = os:cmd("epmd -daemon")),
-    ok.
-
 -spec ensure_distributed() -> ok.
 ensure_distributed() ->
     case erlang:node() of
         'nonode@nohost' ->
-            ensure_epmd(),
             Prefix = atom_to_list(?MODULE),
             Name = random_node_name(Prefix),
             {ok, _Pid} = net_kernel:start([Name, shortnames]),


### PR DESCRIPTION
Summary: When running tests, we manually try to start epmd. As far as I can tell we cargo-culted this, but it is not really necessary, so removing to clean-up

Differential Revision:
D69851994

Privacy Context Container: L1141030


