### PR TITLE
Ensure stdin/stdout of DAP server are in binary more

### DIFF
--- a/edb/src/edb_dap_transport.erl
+++ b/edb/src/edb_dap_transport.erl
@@ -93,6 +93,9 @@ send_event(Event) ->
 
 -spec init(noargs) -> {ok, state()}.
 init(noargs) ->
+    %% Ensure stdin/stdout are in binary mode, so there is no mangling of `\r` on windows, etc
+    io:setopts([binary]),
+
     %% Open stdin/out as a port, requires node to be started with -noinput
     %% We do this to avoid the overhead of the normal Erlang stdout/in stack
     %% which is very significant for raw binary data, mostly because it's prepared


### PR DESCRIPTION
Summary:
# Context
The DAP server communicates with the client via a pipe on stdin/stdout. The protocol uses `\r\n` to delimit frames

# Problem
By default stdin/stdout are in text mode, and when we create a port in `edb_dap_transport`, even though we specify `binary` for the port, the underlying devices are already in `text` mode, so all `\r` are converted by default to `\n`.

This then means that the parsing of DAP frames fail, as we don't get the `\r\n\rn` pattern that we expect

# This diff
Set stdio/stdout to binary mode before opening the port

Differential Revision: D81579173


