### PR TITLE
Docs: changed type in attach requests

### DIFF
--- a/docs/DAP.md
+++ b/docs/DAP.md
@@ -30,7 +30,7 @@ A typical attach request looks like this:
 
 ```json
 {
-  "type": "edb",
+  "type": "erlang-edb",
   "request": "attach",
   "name": "Attach to mynode",
   "config": {
@@ -59,7 +59,7 @@ A typical launch request looks like this:
 
 ```json
 {
-  "type": "edb",
+  "type": "erlang-edb",
   "request": "launch",
   "name": "Launch Erlang Application",
   "runInTerminal": {


### PR DESCRIPTION
So when I was trying to setup `edb` with VSCode it told me that `type: edb` is incorrect, but `type: erlang-edb` worked for me. Not sure if this applies to all editors, if not then feel free to modify this PR or close it
<img width="925" height="382" alt="Screenshot 2025-09-03 at 16 41 23" src="https://github.com/user-attachments/assets/fccf53b6-0cf7-4e70-b5f8-19f7ce3d85f1" />
