### PR TITLE
Remove OTP submodule now that OTP 29 is out (#19)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,34 +14,19 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            otp-version: 27
-            rebar3-version: 3.24.0
+            otp-version: 29
+            rebar3-version: 3.25.0
           - os: macos-latest
-            otp-version: 27
-            rebar3-version: 3.24.0
+            otp-version: 29
+            rebar3-version: 3.25.0
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
         with:
-          submodules: true
-      # - uses: erlef/setup-beam@v1
-        # with:
-          # otp-version: ${{matrix.otp-version}}
-          # TODO(T206197595): Restore once OTP 28 is generally available
-          # rebar3-version: ${{matrix.rebar3-version}}
-      - name: Cache custom Erlang/OTP build
-        uses: actions/cache@v4
-        id: otp-cache
-        with:
-          path: otp-bin
-          key: ${{ runner.os }}-otp-${{ hashFiles(format('{0}{1}', github.workspace, '/otp')) }}
-      - name: Build and install custom version of Erlang/OTP
-        working-directory: otp
-        run: ./configure --prefix=$(pwd)/../otp-bin && make -j$(nproc) && make -j$(nproc) install
-        if: steps.otp-cache.outputs.cache-hit != 'true'
-      - name: Patch PATH
-        run: echo $(pwd)/otp-bin/bin >> $GITHUB_PATH
+          otp-version: ${{matrix.otp-version}}
+          rebar3-version: ${{matrix.rebar3-version}}
       - name: Cache Hex packages
         uses: actions/cache@v4
         with:
@@ -49,18 +34,6 @@ jobs:
           key: ${{ runner.os }}-hex-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.lock')) }}
           restore-keys: |
             ${{ runner.os }}-hex-
-      # TODO(T206197595): Remove once OTP 28 is generally available
-      - name: Checkout rebar3 repository
-        uses: "actions/checkout@v3"
-        with:
-          repository: erlang/rebar3
-          path: rebar3
-          ref: ${{ matrix.rebar3-version }}
-      - name: Bootstrap rebar3
-        run: ./bootstrap
-        working-directory: rebar3
-      - name: Add rebar3 to PATH
-        run: echo $(pwd)/rebar3 >> $GITHUB_PATH
       - name: Compile
         run: rebar3 compile
       - name: Escriptize

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "otp"]
-	path = otp
-	url = https://github.com/jcpetruzza/otp
-	branch = edb-2026-01-19

--- a/README.md
+++ b/README.md
@@ -76,38 +76,16 @@ are building from source and targetting OTP 28.0 or 28.1, use the `otp-28.0` bra
 Moreover, a version of `rebar3` built with Erlang/OTP 26 or higher is required. You can find instructions on how to build `rebar3`
 from source [here](https://rebar3.org/docs/getting-started/#installing-from-source).
 
-### Building the custom version of OTP
-For convenience, a patched version of Erlang/OTP is checked in
-as a git submodule.
+### Installing Erlang/OTP
 
-You can build and install the modified version of Erlang/OTP by doing:
-
-```
-$ git submodule update --init
-$ pushd otp
-$ ./configure --prefix $(pwd)/../otp-bin
-$ make -j$(nproc)
-$ make -j$(nproc) install
-$ popd
-```
-
-**Note:** on Mac you may need to provide a custom installation path
-for OpenSSl. Just replace the above configuration step with:
-
-```
-$ ./configure --prefix $(pwd)/../otp-bin --with-ssl=$(brew --prefix openssl)
-```
-
-Then simply add the installation dir to your `$PATH`:
-
-```
-$ export PATH=$(pwd)/otp-bin/bin:$PATH
-```
+`edb` requires a stock build of Erlang/OTP 29 or later. Install it using your
+preferred method, e.g. [kerl](https://github.com/kerl/kerl),
+[asdf](https://github.com/asdf-vm/asdf-erlang), or your system package manager.
 
 Verify the Erlang installation:
 
 ```
-$ which erl # Should point to the newly built version of Erlang/OTP
+$ erl -version # Should report OTP 29 or later
 ```
 
 ### Building edb itself


### PR DESCRIPTION
Summary:

# Context
`edb` historically depended on a patched fork of Erlang/OTP, checked into the open-source repo as a git submodule. The patches added the debugging extensions `edb` needs. CI built that custom OTP from source on every run, and the README told contributors to do the same locally.

# Problem
OTP 29 ships with all the debugging extensions `edb` requires, so the submodule and the custom-build CI steps can be remove.

# This diff
Switches the GitHub Actions workflow to install stock OTP 29 via `erlef/setup-beam` and drops the submodule.

Differential Revision: D106390371
