### PR TITLE
Support a configurable module lookup from a path

### DIFF
--- a/apps/edb/src/edb_dap_request_set_breakpoints.erl
+++ b/apps/edb/src/edb_dap_request_set_breakpoints.erl
@@ -200,25 +200,25 @@ parse_arguments(Args) ->
 -spec handle(State, Args) -> edb_dap_request:reaction(response()) when
     State :: edb_dap_server:state(),
     Args :: arguments().
-handle(#{state := configuring}, Args) ->
-    set_breakpoints(Args);
-handle(#{state := attached}, Args) ->
-    set_breakpoints(Args);
+handle(State = #{state := configuring}, Args) ->
+    set_breakpoints(State, Args);
+handle(State = #{state := attached}, Args) ->
+    set_breakpoints(State, Args);
 handle(_UnexpectedState, _) ->
     edb_dap_request:unexpected_request().
 
 %% ------------------------------------------------------------------
 %% Helpers
 %% ------------------------------------------------------------------
--spec set_breakpoints(Args) -> edb_dap_request:reaction(response()) when
+-spec set_breakpoints(State, Args) -> edb_dap_request:reaction(response()) when
+    State :: edb_dap_server:state(),
     Args :: arguments().
-set_breakpoints(Args = #{source := #{path := Path}}) ->
-    Module = binary_to_atom(filename:basename(Path, ".erl")),
-
+set_breakpoints(State0, Args = #{source := #{path := Path}}) ->
     SourceBreakpoints = maps:get(breakpoints, Args, []),
     SourceBreakpointLines = [Line || #{line := Line} <- SourceBreakpoints],
+    {Modules, State1} = source_path_to_modules(Path, SourceBreakpointLines, State0),
 
-    LineResults = edb:set_breakpoints(Module, SourceBreakpointLines),
+    LineResults = set_breakpoints_in_modules(Modules, SourceBreakpointLines),
 
     Breakpoints = [
         case Result of
@@ -230,7 +230,91 @@ set_breakpoints(Args = #{source := #{path := Path}}) ->
         end
      || {Line, Result} <:- LineResults
     ],
-    #{response => edb_dap_request:success(#{breakpoints => Breakpoints})}.
+    #{
+        response => edb_dap_request:success(#{breakpoints => Breakpoints}),
+        new_state => State1
+    }.
+
+-spec source_path_to_modules(Path, Lines, State) -> {Modules, edb_dap_server:state()} when
+    Path :: binary(),
+    Lines :: [edb:line()],
+    Modules :: [module()],
+    State :: edb_dap_server:state().
+source_path_to_modules(Path, Lines, State) ->
+    SourceModules = maps:get(source_modules, State, #{}),
+    CachedModules = maps:get(Path, SourceModules, []),
+    ConfiguredModules =
+        case {Lines, CachedModules} of
+            {[], [_ | _]} -> [];
+            _ -> configured_source_path_to_modules(Path)
+        end,
+    Modules =
+        case {Lines, CachedModules, ConfiguredModules} of
+            {[], [_ | _] = Modules0, _} ->
+                Modules0;
+            {_, _, [_ | _] = Modules0} ->
+                Modules0;
+            {_, [_ | _] = Modules0, _} ->
+                Modules0;
+            _ ->
+                Extension = filename:extension(Path),
+                ModuleName = filename:basename(Path, Extension),
+                [binary_to_atom(unicode:characters_to_binary(ModuleName))]
+        end,
+    State1 =
+        case {Lines, ConfiguredModules} of
+            {[], _} ->
+                State#{source_modules => maps:remove(Path, SourceModules)};
+            {_, [_ | _]} ->
+                State#{source_modules => SourceModules#{Path => Modules}};
+            _ ->
+                State
+        end,
+    {Modules, State1}.
+
+-spec configured_source_path_to_modules(Path :: binary()) -> [module()].
+configured_source_path_to_modules(Path) ->
+    Eval = fun() ->
+        case application:get_env(edb, file_to_module_cb, undefined) of
+            {eval, Fun} when is_function(Fun, 1) ->
+                Fun(Path);
+            _ ->
+                []
+        end
+    end,
+    case edb:eval(#{function => Eval, timeout => 5_000}) of
+        {ok, Modules} -> Modules;
+        _ -> []
+    end.
+
+-spec set_breakpoints_in_modules(Modules, Lines) -> edb:set_breakpoints_result() when
+    Modules :: [module()],
+    Lines :: [edb:line()].
+set_breakpoints_in_modules([Module], Lines) ->
+    edb:set_breakpoints(Module, Lines);
+set_breakpoints_in_modules(Modules, Lines) ->
+    ResultsByModule = [edb:set_breakpoints(Module, Lines) || Module <- Modules],
+    [{Line, merge_line_results(Line, ResultsByModule)} || Line <- Lines].
+
+-spec merge_line_results(Line, ResultsByModule) -> ok | {error, edb:add_breakpoint_error()} when
+    Line :: edb:line(),
+    ResultsByModule :: [edb:set_breakpoints_result()].
+merge_line_results(Line, ResultsByModule) ->
+    LineResults = [
+        Result
+     || ModuleResults <- ResultsByModule,
+        {ResultLine, Result} <- ModuleResults,
+        ResultLine =:= Line
+    ],
+    case lists:member(ok, LineResults) of
+        true ->
+            ok;
+        false ->
+            case LineResults of
+                [{error, Reason} | _] -> {error, Reason};
+                [] -> {error, {badkey, Line}}
+            end
+    end.
 
 -spec format_breakpoint_error(Error) -> binary() when
     Error :: edb:add_breakpoint_error().

--- a/apps/edb/src/edb_dap_server.erl
+++ b/apps/edb/src/edb_dap_server.erl
@@ -77,6 +77,7 @@ For details see https://microsoft.github.io/debug-adapter-protocol/specification
         shell_process_id => number(),
         reverse_attach_ref := reference(),
         cwd := binary(),
+        source_modules => #{binary() => [module()]},
         subscription := edb:event_subscription()
     }
     | #{
@@ -91,6 +92,7 @@ For details see https://microsoft.github.io/debug-adapter-protocol/specification
         node := node(),
         reverse_attach_ref := reference() | undefined,
         cwd := binary(),
+        source_modules => #{binary() => [module()]},
         subscription := edb:event_subscription()
     }
     | #{
@@ -102,6 +104,7 @@ For details see https://microsoft.github.io/debug-adapter-protocol/specification
         node := node(),
         reverse_attach_ref := reference() | undefined,
         cwd := binary(),
+        source_modules => #{binary() => [module()]},
         subscription := edb:event_subscription()
     }
     | #{

--- a/apps/edb/test/edb_dap_set_breakpoints_SUITE.erl
+++ b/apps/edb/test/edb_dap_set_breakpoints_SUITE.erl
@@ -31,11 +31,17 @@
 %% Test cases
 -export([test_error_set_breakpoint_bad_line/1]).
 -export([test_error_set_breakpoint_unknown_module/1]).
+-export([test_set_breakpoint_by_source_module_callback/1]).
+-export([test_clear_breakpoints_removes_cached_source_modules/1]).
+-export([test_set_breakpoint_by_module_name_when_source_lookup_unavailable/1]).
 
 all() ->
     [
         test_error_set_breakpoint_bad_line,
-        test_error_set_breakpoint_unknown_module
+        test_error_set_breakpoint_unknown_module,
+        test_set_breakpoint_by_source_module_callback,
+        test_clear_breakpoints_removes_cached_source_modules,
+        test_set_breakpoint_by_module_name_when_source_lookup_unavailable
     ].
 
 init_per_testcase(_TestCase, Config) ->
@@ -150,3 +156,192 @@ test_error_set_breakpoint_unknown_module(Config) ->
         Response
     ),
     ok.
+
+test_set_breakpoint_by_source_module_callback(Config) ->
+    {ok, Client, #{peer := Peer, srcdir := SrcDir}} = edb_dap_test_support:start_session_via_launch(Config, #{
+        modules => [
+            {source, [
+                ~"-module(edb_source_breakpoint_one).\n",
+                ~"-export([go/0]).\n",
+                ~"go() -> ok.\n"
+            ]},
+            {source, [
+                ~"-module(edb_source_breakpoint_two).\n",
+                ~"-export([go/0]).\n",
+                ~"go() ->\n",
+                ~"    ok.\n"
+            ]},
+            {source, [
+                ~"-module(edb_source_breakpoint_cb).\n",
+                ~"-export([modules/1]).\n",
+                ~"modules(_) ->\n",
+                ~"    [edb_source_breakpoint_one, edb_source_breakpoint_two].\n"
+            ]}
+        ]
+    }),
+    SourcePath = filename:join(edb_test_support:file_name_all_to_string(SrcDir), "breakpoint.erl"),
+    SourcePathBin = edb_test_support:safe_string_to_binary(SourcePath),
+
+    ok = edb_dap_test_support:configure(Client, []),
+    ok = peer:call(Peer, application, set_env, [
+        edb, file_to_module_cb, {eval, fun edb_source_breakpoint_cb:modules/1}
+    ]),
+
+    Response = edb_dap_test_client:set_breakpoints(Client, #{
+        source => #{path => SourcePathBin},
+        breakpoints => [#{line => 3}, #{line => 4}, #{line => 42}]
+    }),
+
+    ?assertMatch(
+        #{
+            command := ~"setBreakpoints",
+            type := response,
+            success := true,
+            body :=
+                #{
+                    breakpoints :=
+                        [
+                            #{line := 3, verified := true},
+                            #{line := 4, verified := true},
+                            #{
+                                line := 42,
+                                message := ~"Line is not executable",
+                                reason := ~"failed",
+                                verified := false
+                            }
+                        ]
+                }
+        },
+        Response
+    ),
+    ok.
+
+test_clear_breakpoints_removes_cached_source_modules(Config) ->
+    Module1 = edb_cached_source_breakpoint_one,
+    Module2 = edb_cached_source_breakpoint_two,
+
+    {ok, Client, #{peer := Peer, node := Node, srcdir := SrcDir}} =
+        edb_dap_test_support:start_session_via_launch(Config, #{
+            modules => [
+                {source, [
+                    ~"-module(edb_cached_source_breakpoint_one).\n",
+                    ~"-export([go/0]).\n",
+                    ~"go() -> ok.\n"
+                ]},
+                {source, [
+                    ~"-module(edb_cached_source_breakpoint_two).\n",
+                    ~"-export([go/0]).\n",
+                    ~"go() ->\n",
+                    ~"    ok.\n"
+                ]},
+                {source, [
+                    ~"-module(edb_cached_source_breakpoint_cb).\n",
+                    ~"-export([modules/1]).\n",
+                    ~"modules(_) ->\n",
+                    ~"    [edb_cached_source_breakpoint_one, edb_cached_source_breakpoint_two].\n"
+                ]}
+            ]
+        }),
+    SourcePath = filename:join(edb_test_support:file_name_all_to_string(SrcDir), "cached_breakpoint.erl"),
+    SourcePathBin = edb_test_support:safe_string_to_binary(SourcePath),
+
+    ok = edb_dap_test_support:configure(Client, []),
+    ok = peer:call(Peer, application, set_env, [
+        edb, file_to_module_cb, {eval, fun edb_cached_source_breakpoint_cb:modules/1}
+    ]),
+
+    SetResponse = edb_dap_test_client:set_breakpoints(Client, #{
+        source => #{path => SourcePathBin},
+        breakpoints => [#{line => 3}, #{line => 4}]
+    }),
+    ?assertMatch(
+        #{
+            command := ~"setBreakpoints",
+            type := response,
+            success := true,
+            body := #{breakpoints := [#{line := 3, verified := true}, #{line := 4, verified := true}]}
+        },
+        SetResponse
+    ),
+    ?assertMatch(
+        #{
+            Module1 := [#{line := 3, module := Module1, type := line}],
+            Module2 := [#{line := 4, module := Module2, type := line}]
+        },
+        target_breakpoints(Peer, Node)
+    ),
+
+    ok = peer:call(Peer, application, unset_env, [edb, file_to_module_cb]),
+    ClearResponse = edb_dap_test_client:set_breakpoints(Client, #{
+        source => #{path => SourcePathBin},
+        breakpoints => []
+    }),
+    ?assertMatch(
+        #{
+            command := ~"setBreakpoints",
+            type := response,
+            success := true,
+            body := #{breakpoints := []}
+        },
+        ClearResponse
+    ),
+    ?assertEqual(#{}, target_breakpoints(Peer, Node)),
+
+    SetAfterClearResponse = edb_dap_test_client:set_breakpoints(Client, #{
+        source => #{path => SourcePathBin},
+        breakpoints => [#{line => 3}]
+    }),
+    ?assertMatch(
+        #{
+            command := ~"setBreakpoints",
+            type := response,
+            success := true,
+            body :=
+                #{
+                    breakpoints :=
+                        [
+                            #{
+                                line := 3,
+                                message := ~"Module not found or failing to load",
+                                reason := ~"failed",
+                                verified := false
+                            }
+                        ]
+                }
+        },
+        SetAfterClearResponse
+    ),
+    ok.
+
+test_set_breakpoint_by_module_name_when_source_lookup_unavailable(Config) ->
+    {ok, Client, #{srcdir := SrcDir}} = edb_dap_test_support:start_session_via_launch(Config, #{
+        modules => [
+            {source, [
+                ~"-module(edb_no_source_breakpoint).\n",
+                ~"-export([go/0]).\n",
+                ~"go() ->\n",
+                ~"    ok.\n"
+            ]}
+        ]
+    }),
+    SourcePath = filename:join(edb_test_support:file_name_all_to_string(SrcDir), "edb_no_source_breakpoint.erl"),
+    ok = edb_dap_test_support:configure(Client, []),
+
+    Response = edb_dap_test_client:set_breakpoints(Client, #{
+        source => #{path => edb_test_support:safe_string_to_binary(SourcePath)},
+        breakpoints => [#{line => 4}]
+    }),
+
+    ?assertMatch(
+        #{
+            command := ~"setBreakpoints",
+            type := response,
+            success := true,
+            body := #{breakpoints := [#{line := 4, verified := true}]}
+        },
+        Response
+    ),
+    ok.
+
+target_breakpoints(Peer, Node) ->
+    peer:call(Peer, edb_server, call, [Node, get_breakpoints]).


### PR DESCRIPTION
Erlang has a constraint that ensures there is a mapping from filename to module name:

```
foo.erl => -module(foo)
bar.erl => -module(bar)
```

This makes looking up a module based on a path name deterministic. This is not the case in other BEAM languages such as Elixir. In Elixir, there is no mapping between the file name and the module name. It is also possible for an Elixir file to contain multiple modules.

In order to allow edb to be used in Elixir, we need a way to configure the mapping from path to module. However, instead of baking in support just for Elixir, it would be ideal to have this be generic.

This commit introduces a configurable function which can be provided on the target and called with `edb:eval`. This is configured using the `file_to_module_cb` application config. This is expected to return a list of modules, which will then be used for setting breakpoints on the module.

This does introduce another issue though. When removing a breakpoint, if the module is changed in any way, or it is not possible to call the same lookup function, it may not be possible to unset the breakpoint. For this reason, the lookup is cached, and if the breakpoints are set to any empty list, then the cached module lookup is used and removed from the cache.